### PR TITLE
ShopifyLite fix and CleanCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ module.exports = {
         shopName: process.env.GATSBY_SHOP_NAME,
         accessToken: process.env.GATSBY_SHOPIFY_ACCESS_TOKEN,
         basePath: '/',
+        shopifyLite: ; false,
       },
     },
   ],
@@ -117,7 +118,7 @@ Please make sure that your Shopify web store has at least one [Collection](https
 
 ### A setup for Shopify Lite plan
 
-If you are using Shopify Lite plan. Please set `shopifyLite` property to `ture` in `gatsby-config.js`. This will disable generation of pages for Blog and Pages as they are not avalible in "Lite" plan.
+If you are using Shopify Lite plan. Please set `shopifyLite` property to `true` in `@gatsbystorefront/gatsby-theme-storefront-shopify` plugin `options` in `gatsby-config.js`. This will disable generation of pages for Blog and Pages as they are not avalible in "Lite" plan.
 
 ### Starter
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,4 @@
-module.exports = ({ shopName, accessToken }) => ({
+module.exports = ({ shopName, accessToken, shopifyLite = false }) => ({
   plugins: [
     {
       resolve: 'gatsby-source-shopify',
@@ -76,7 +76,7 @@ module.exports = ({ shopName, accessToken }) => ({
       // For available socia share buttons see: https://github.com/nygardk/react-share
       shareButtons: [],
       googleAnalyticsId: 'UA-141525658-3',
-      shopifyLite: false,
+      isShopifyLite: shopifyLite,
       //
       // carousel, collection, product
       //

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -329,30 +329,7 @@ exports.createPages = async ({ graphql, actions }, options) => {
 
   // In case Shopify Lite plan we don't have data to create Pages, Blogs and Articles
   if (!isShopifyLite) {
-    const queryPages = await graphql(`
-      {
-        pages: allShopifyPage {
-          nodes {
-            handle
-            fields {
-              shopifyThemePath
-            }
-          }
-        }
-      }
-    `);
-    queryPages.data.pages.nodes.forEach(({ handle, fields }) => {
-      const { shopifyThemePath } = fields;
-      createPage({
-        path: shopifyThemePath,
-        component: pageTemplate,
-        context: {
-          handle,
-          // Todo: Find a better way to do this.
-          cartUrl: finalCartPagePath,
-        },
-      });
-    });
+    await createPagePages(graphql, createPage, finalCartPagePath);
 
     const queryArticles = await createArticlePages(graphql, createPage, finalCartPagePath);
 
@@ -405,6 +382,33 @@ exports.sourceNodes = ({ actions }) => {
     createTypes(typeDefs);
   }
 };
+async function createPagePages(graphql, createPage, finalCartPagePath) {
+  const queryPages = await graphql(`
+      {
+        pages: allShopifyPage {
+          nodes {
+            handle
+            fields {
+              shopifyThemePath
+            }
+          }
+        }
+      }
+    `);
+  queryPages.data.pages.nodes.forEach(({ handle, fields }) => {
+    const { shopifyThemePath } = fields;
+    createPage({
+      path: shopifyThemePath,
+      component: pageTemplate,
+      context: {
+        handle,
+        // Todo: Find a better way to do this.
+        cartUrl: finalCartPagePath,
+      },
+    });
+  });
+}
+
 async function createArticlePages(graphql, createPage, finalCartPagePath) {
   const queryArticles = await graphql(`
       {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -150,7 +150,7 @@ exports.createSchemaCustomization =({ actions }) => {
   createTypes(typeDefs);
 };
 
-function createProductNode(options, actions, node) {
+const createProductNode = (options, actions, node) => {
   let { basePath = '', productPageBasePath = 'product' } = options;
   const { createNodeField } = actions;
   basePath = removeTrailingLeadingSlashes(basePath);
@@ -163,7 +163,7 @@ function createProductNode(options, actions, node) {
   });
 }
 
-function createCollectionNode(options, actions, node) {
+const createCollectionNode = (options, actions, node) => {
   let { basePath = '', collectionPageBasePath = 'collection' } = options;
   const { createNodeField } = actions;
   basePath = removeTrailingLeadingSlashes(basePath);
@@ -176,7 +176,7 @@ function createCollectionNode(options, actions, node) {
   });
 }
 
-function createShopPolicyNode(options, actions, node) {
+const createShopPolicyNode = (options, actions, node) => {
   let { basePath = '', policyPageBasePath = 'policy' } = options;
   const { createNodeField } = actions;
   basePath = removeTrailingLeadingSlashes(basePath);
@@ -189,7 +189,7 @@ function createShopPolicyNode(options, actions, node) {
   });
 }
 
-function createPageNode(options, actions, node) {
+const createPageNode = (options, actions, node) => {
   let { basePath = '', pageBasePath = 'pages' } = options;
   const { createNodeField } = actions;
   basePath = removeTrailingLeadingSlashes(basePath);
@@ -203,7 +203,7 @@ function createPageNode(options, actions, node) {
   });
 }
 
-async function createBlogNode(options, actions, node, cache) {
+const createBlogNode = async (options, actions, node, cache) => {
   let { basePath = '', blogPageBasePath = 'blog' } = options;
   const { createNodeField } = actions;
   basePath = removeTrailingLeadingSlashes(basePath);
@@ -236,7 +236,7 @@ async function createBlogNode(options, actions, node, cache) {
   });
 }
 
-async function createArticleNode(options, actions, node, cache) {
+const createArticleNode = async (options, actions, node, cache) => {
   let { basePath = '', articlePageBasePath = 'article', blogPageBasePath = 'blog', } = options;
   const { createNodeField } = actions;
   basePath = removeTrailingLeadingSlashes(basePath);
@@ -260,7 +260,7 @@ async function createArticleNode(options, actions, node, cache) {
   });
 }
 
-async function createMainPage(basePath, graphql, createPage) {
+const createMainPage = async (basePath, graphql, createPage) => {
   const mainPagePath = `${basePath && `/${basePath}`}/`;
   const mainPageHandles = await graphql(`
     {
@@ -290,7 +290,7 @@ async function createMainPage(basePath, graphql, createPage) {
   });
 }
 
-async function createCollectionsPages(graphql, productsPerCollectionPage, createPage, finalCartPagePath) {
+const createCollectionsPages = async (graphql, productsPerCollectionPage, createPage, finalCartPagePath) => {
   const queryCollections = await graphql(`
     {
       collections: allShopifyCollection {
@@ -332,7 +332,7 @@ async function createCollectionsPages(graphql, productsPerCollectionPage, create
   });
 }
 
-async function createProductsPages(graphql, createPage, finalCartPagePath) {
+const createProductsPages = async (graphql, createPage, finalCartPagePath) => {
   const queryProducts = await graphql(`
     {
       products: allShopifyProduct {
@@ -359,7 +359,7 @@ async function createProductsPages(graphql, createPage, finalCartPagePath) {
   });
 }
 
-async function createPoliciesPages(graphql, createPage, finalCartPagePath) {
+const createPoliciesPages = async (graphql, createPage, finalCartPagePath) => {
   const queryPolicies = await graphql(`
     {
       policies: allShopifyShopPolicy {
@@ -386,7 +386,7 @@ async function createPoliciesPages(graphql, createPage, finalCartPagePath) {
   });
 }
 
-async function createPagePages(graphql, createPage, finalCartPagePath) {
+const createPagePages = async (graphql, createPage, finalCartPagePath) => {
   const queryPages = await graphql(`
       {
         pages: allShopifyPage {
@@ -413,7 +413,7 @@ async function createPagePages(graphql, createPage, finalCartPagePath) {
   });
 }
 
-async function createArticlePages(graphql, createPage, finalCartPagePath) {
+const createArticlePages = async (graphql, createPage, finalCartPagePath) => {
   const queryArticles = await graphql(`
       {
         articles: allShopifyArticle {
@@ -444,7 +444,7 @@ async function createArticlePages(graphql, createPage, finalCartPagePath) {
   return queryArticles;
 }
 
-async function createBlogPages(graphql, queryArticles, articlesPerBlogPage, createPage, finalCartPagePath) {
+const createBlogPages = async (graphql, queryArticles, articlesPerBlogPage, createPage, finalCartPagePath) => {
   const queryBlogs = await graphql(`
       {
         blogs: allShopifyBlog {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -32,6 +32,10 @@ const getMainPageHandles = mainPage => {
   return handles;
 };
 
+exports.onPreInit = (_, pluginOptions) => {
+  isShopifyLite = pluginOptions.shopifyLite;
+}
+
 exports.onCreateNode = async ({ node, actions, cache }, options) => {
   switch (node.internal.type) {
     case `ShopifyProduct`:
@@ -61,7 +65,6 @@ exports.createPages = async ({ graphql, actions }, options) => {
       site {
         siteMetadata {
           gatsbyStorefrontConfig {
-            shopifyLite
             productsPerCollectionPage
             articlesPerBlogPage
           }
@@ -72,9 +75,7 @@ exports.createPages = async ({ graphql, actions }, options) => {
   const {
     productsPerCollectionPage = 9,
     articlesPerBlogPage = 6,
-    shopifyLite = false,
   } = gatsbyStorefrontConfig.data.site.siteMetadata.gatsbyStorefrontConfig;
-  isShopifyLite = shopifyLite;
 
   const { createPage } = actions;
   let { cartPagePath = 'cart', basePath = '' } = options;
@@ -110,44 +111,47 @@ exports.createSchemaCustomization =({ actions }) => {
   // In case using Shopify Lite plan GraphQL nodes for Articles and Pages are not created.
   // While build process GatsbyJS extracts queries and checks them against schema (see https://www.gatsbyjs.org/docs/query-extraction/).
   // Here we are creating mock data, so the queries could pass validation.
-  
-  const typeDefs = `
-      type ShopifyArticleFields {
-        shopifyThemePath: String
-      }
-      type ShopifyBlog implements Node {
-        Name: String
-        title: String
-        url: String
-        shopifyId: String
-        fields: ShopifyArticleFields
-      }
-      type ShopifyArticle implements Node {
-        Name: String
-        content: String
-        contentHtml: String
-        excerpt: String
-        excerptHtml: String
-        blog: ShopifyBlog
-        publishedAt(formatString: String): Date
-        title: String
-        url: String
-        shopifyId: String
-        fields: ShopifyArticleFields
-      }
-      type ShopifyPage implements Node {
-        Name: String
-        handle: String
-        title: String
-        body: String
-        bodySummary: String
-        updatedAt(formatString: String): Date
-        url: String
-        shopifyId: String
-        fields: ShopifyArticleFields
-      }
-  `;
-  createTypes(typeDefs);
+  if (isShopifyLite){
+    console.log('>>>>>>>>>>>>>>', isShopifyLite);
+
+    const typeDefs = `
+        type ShopifyArticleFields {
+          shopifyThemePath: String
+        }
+        type ShopifyBlog implements Node {
+          Name: String
+          title: String
+          url: String
+          shopifyId: String
+          fields: ShopifyArticleFields
+        }
+        type ShopifyArticle implements Node {
+          Name: String
+          content: String
+          contentHtml: String
+          excerpt: String
+          excerptHtml: String
+          blog: ShopifyBlog
+          publishedAt(formatString: String): Date
+          title: String
+          url: String
+          shopifyId: String
+          fields: ShopifyArticleFields
+        }
+        type ShopifyPage implements Node {
+          Name: String
+          handle: String
+          title: String
+          body: String
+          bodySummary: String
+          updatedAt(formatString: String): Date
+          url: String
+          shopifyId: String
+          fields: ShopifyArticleFields
+        }
+    `;
+    createTypes(typeDefs);
+  }
 };
 
 const createProductNode = (options, actions, node) => {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -354,34 +354,7 @@ exports.createPages = async ({ graphql, actions }, options) => {
       });
     });
 
-    const queryArticles = await graphql(`
-      {
-        articles: allShopifyArticle {
-          nodes {
-            shopifyId
-            fields {
-              shopifyThemePath
-            }
-            blog {
-              shopifyId
-            }
-          }
-        }
-      }
-    `);
-
-    queryArticles.data.articles.nodes.forEach(({ shopifyId, fields }) => {
-      const { shopifyThemePath } = fields;
-      createPage({
-        path: shopifyThemePath,
-        component: articleTemplate,
-        context: {
-          shopifyId,
-          // Todo: Find a better way to do this.
-          cartUrl: finalCartPagePath,
-        },
-      });
-    });
+    const queryArticles = await createArticlePages(graphql, createPage, finalCartPagePath);
 
     await createBlogPages(graphql, queryArticles, articlesPerBlogPage, createPage, finalCartPagePath);
   }
@@ -432,6 +405,37 @@ exports.sourceNodes = ({ actions }) => {
     createTypes(typeDefs);
   }
 };
+async function createArticlePages(graphql, createPage, finalCartPagePath) {
+  const queryArticles = await graphql(`
+      {
+        articles: allShopifyArticle {
+          nodes {
+            shopifyId
+            fields {
+              shopifyThemePath
+            }
+            blog {
+              shopifyId
+            }
+          }
+        }
+      }
+    `);
+  queryArticles.data.articles.nodes.forEach(({ shopifyId, fields }) => {
+    const { shopifyThemePath } = fields;
+    createPage({
+      path: shopifyThemePath,
+      component: articleTemplate,
+      context: {
+        shopifyId,
+        // Todo: Find a better way to do this.
+        cartUrl: finalCartPagePath,
+      },
+    });
+  });
+  return queryArticles;
+}
+
 async function createBlogPages(graphql, queryArticles, articlesPerBlogPage, createPage, finalCartPagePath) {
   const queryBlogs = await graphql(`
       {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -302,30 +302,7 @@ exports.createPages = async ({ graphql, actions }, options) => {
     });
   });
 
-  const queryPolicies = await graphql(`
-    {
-      policies: allShopifyShopPolicy {
-        nodes {
-          type
-          fields {
-            shopifyThemePath
-          }
-        }
-      }
-    }
-  `);
-  queryPolicies.data.policies.nodes.forEach(({ type, fields }) => {
-    const { shopifyThemePath } = fields;
-    createPage({
-      path: shopifyThemePath,
-      component: policyTemplate,
-      context: {
-        type,
-        // Todo: Find a better way to do this.
-        cartUrl: finalCartPagePath,
-      },
-    });
-  });
+  await createPoliciesPages(graphql, createPage, finalCartPagePath);
 
   // In case Shopify Lite plan we don't have data to create Pages, Blogs and Articles
   if (!isShopifyLite) {
@@ -382,6 +359,33 @@ exports.sourceNodes = ({ actions }) => {
     createTypes(typeDefs);
   }
 };
+async function createPoliciesPages(graphql, createPage, finalCartPagePath) {
+  const queryPolicies = await graphql(`
+    {
+      policies: allShopifyShopPolicy {
+        nodes {
+          type
+          fields {
+            shopifyThemePath
+          }
+        }
+      }
+    }
+  `);
+  queryPolicies.data.policies.nodes.forEach(({ type, fields }) => {
+    const { shopifyThemePath } = fields;
+    createPage({
+      path: shopifyThemePath,
+      component: policyTemplate,
+      context: {
+        type,
+        // Todo: Find a better way to do this.
+        cartUrl: finalCartPagePath,
+      },
+    });
+  });
+}
+
 async function createPagePages(graphql, createPage, finalCartPagePath) {
   const queryPages = await graphql(`
       {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -197,39 +197,7 @@ exports.createPages = async ({ graphql, actions }, options) => {
     component: cartTemplate,
   });
 
-  const mainPagePath = `${basePath && `/${basePath}`}/`;
-  const mainPageHandles = await graphql(`
-    {
-      site {
-        siteMetadata {
-          gatsbyStorefrontConfig {
-            mainPage {
-              handle
-              type
-              children {
-                handle
-                type
-              }
-            }
-          }
-        }
-      }
-    }
-  `);
-  const mainPageHandlesArray = getMainPageHandles(
-    JSON.parse(
-      JSON.stringify(
-        mainPageHandles.data.site.siteMetadata.gatsbyStorefrontConfig.mainPage
-      )
-    )
-  );
-  createPage({
-    path: mainPagePath,
-    component: mainPageTemplate,
-    context: {
-      handles: mainPageHandlesArray,
-    },
-  });
+  await createMainPage(basePath, graphql, createPage);
 
   await createCollectionsPages(graphql, productsPerCollectionPage, createPage, finalCartPagePath);
 
@@ -292,6 +260,36 @@ exports.sourceNodes = ({ actions }) => {
     createTypes(typeDefs);
   }
 };
+async function createMainPage(basePath, graphql, createPage) {
+  const mainPagePath = `${basePath && `/${basePath}`}/`;
+  const mainPageHandles = await graphql(`
+    {
+      site {
+        siteMetadata {
+          gatsbyStorefrontConfig {
+            mainPage {
+              handle
+              type
+              children {
+                handle
+                type
+              }
+            }
+          }
+        }
+      }
+    }
+  `);
+  const mainPageHandlesArray = getMainPageHandles(JSON.parse(JSON.stringify(mainPageHandles.data.site.siteMetadata.gatsbyStorefrontConfig.mainPage)));
+  createPage({
+    path: mainPagePath,
+    component: mainPageTemplate,
+    context: {
+      handles: mainPageHandlesArray,
+    },
+  });
+}
+
 async function createCollectionsPages(graphql, productsPerCollectionPage, createPage, finalCartPagePath) {
   const queryCollections = await graphql(`
     {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -34,19 +34,7 @@ const getMainPageHandles = mainPage => {
 
 exports.onCreateNode = async ({ node, actions, cache }, options) => {
   if (node.internal.type === `ShopifyProduct`) {
-    let { basePath = '', productPageBasePath = 'product' } = options;
-    const { createNodeField } = actions;
-    basePath = removeTrailingLeadingSlashes(basePath);
-    productPageBasePath = removeTrailingLeadingSlashes(productPageBasePath);
-
-    // Todo: Improve the way this is done. Maybe using the config.json file.
-    createNodeField({
-      node,
-      name: 'shopifyThemePath',
-      value: `${basePath && `/${basePath}`}/${productPageBasePath}/${
-        node.handle
-      }`,
-    });
+    createProductNode(options, actions, node);
   }
 
   if (node.internal.type === `ShopifyCollection`) {
@@ -165,6 +153,19 @@ exports.sourceNodes = ({ actions }) => {
     createTypes(typeDefs);
   }
 };
+function createProductNode(options, actions, node) {
+  let { basePath = '', productPageBasePath = 'product' } = options;
+  const { createNodeField } = actions;
+  basePath = removeTrailingLeadingSlashes(basePath);
+  productPageBasePath = removeTrailingLeadingSlashes(productPageBasePath);
+  // Todo: Improve the way this is done. Maybe using the config.json file.
+  createNodeField({
+    node,
+    name: 'shopifyThemePath',
+    value: `${basePath && `/${basePath}`}/${productPageBasePath}/${node.handle}`,
+  });
+}
+
 function createCollectionNode(options, actions, node) {
   let { basePath = '', collectionPageBasePath = 'collection' } = options;
   const { createNodeField } = actions;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -133,35 +133,7 @@ exports.onCreateNode = async ({ node, actions, cache }, options) => {
   }
 
   if (node.internal.type === `ShopifyArticle`) {
-    let {
-      basePath = '',
-      articlePageBasePath = 'article',
-      blogPageBasePath = 'blog',
-    } = options;
-    const { createNodeField } = actions;
-    basePath = removeTrailingLeadingSlashes(basePath);
-    if (articlePageBasePath.length > 0) {
-      articlePageBasePath = removeTrailingLeadingSlashes(articlePageBasePath);
-    }
-
-    let nodeArticleUrlArray = node.url.split('/');
-    let articleHandle = nodeArticleUrlArray[nodeArticleUrlArray.length - 1];
-
-    let blogs = await cache.get('availableBlogs');
-
-    blogs.forEach(blog => {
-      const { shopifyId, handle: blogHandle } = blog;
-
-      if (shopifyId === node.blog.id) {
-        createNodeField({
-          node,
-          name: 'shopifyThemePath',
-          value: `${basePath && `/${basePath}`}${blogPageBasePath &&
-            `/${blogPageBasePath}`}/${blogHandle}${articlePageBasePath &&
-            `/${articlePageBasePath}`}/${articleHandle}`,
-        });
-      }
-    });
+    await createArticleNode(options, actions, node, cache);
   }
 };
 
@@ -260,6 +232,30 @@ exports.sourceNodes = ({ actions }) => {
     createTypes(typeDefs);
   }
 };
+async function createArticleNode(options, actions, node, cache) {
+  let { basePath = '', articlePageBasePath = 'article', blogPageBasePath = 'blog', } = options;
+  const { createNodeField } = actions;
+  basePath = removeTrailingLeadingSlashes(basePath);
+  if (articlePageBasePath.length > 0) {
+    articlePageBasePath = removeTrailingLeadingSlashes(articlePageBasePath);
+  }
+  let nodeArticleUrlArray = node.url.split('/');
+  let articleHandle = nodeArticleUrlArray[nodeArticleUrlArray.length - 1];
+  let blogs = await cache.get('availableBlogs');
+  blogs.forEach(blog => {
+    const { shopifyId, handle: blogHandle } = blog;
+    if (shopifyId === node.blog.id) {
+      createNodeField({
+        node,
+        name: 'shopifyThemePath',
+        value: `${basePath && `/${basePath}`}${blogPageBasePath &&
+          `/${blogPageBasePath}`}/${blogHandle}${articlePageBasePath &&
+          `/${articlePageBasePath}`}/${articleHandle}`,
+      });
+    }
+  });
+}
+
 async function createMainPage(basePath, graphql, createPage) {
   const mainPagePath = `${basePath && `/${basePath}`}/`;
   const mainPageHandles = await graphql(`

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -97,39 +97,7 @@ exports.onCreateNode = async ({ node, actions, cache }, options) => {
   }
 
   if (node.internal.type === `ShopifyBlog`) {
-    let { basePath = '', blogPageBasePath = 'blog' } = options;
-    const { createNodeField } = actions;
-    basePath = removeTrailingLeadingSlashes(basePath);
-    if (blogPageBasePath.length > 0) {
-      blogPageBasePath = removeTrailingLeadingSlashes(blogPageBasePath);
-    }
-
-    let nodeUrlArray = node.url.split('/');
-    let blogHandle = nodeUrlArray[nodeUrlArray.length - 1];
-
-    // As while creating only new nodes we do not know about already existing
-    // We need to store information about blogs received early in cache.
-    // 1. Push new blogs to array
-    availableBlogs.push({
-      shopifyId: node.shopifyId,
-      handle: blogHandle,
-    });
-    // 2. Receive already known blogs from cache
-    let blogs = await cache.get('availableBlogs');
-    // 3. Concat new blogs with already known
-    if (blogs && blogs.length > 0) {
-      availableBlogs = availableBlogs.concat(blogs);
-    }
-    // 4. Write back to cache
-    await cache.set('availableBlogs', availableBlogs);
-
-    // Todo: Improve the way this is done. Maybe using the config.json file.
-    createNodeField({
-      node,
-      name: 'shopifyThemePath',
-      value: `${basePath && `/${basePath}`}${blogPageBasePath &&
-        `/${blogPageBasePath}`}/${blogHandle}`,
-    });
+    await createBlogNode(options, actions, node, cache);
   }
 
   if (node.internal.type === `ShopifyArticle`) {
@@ -232,6 +200,39 @@ exports.sourceNodes = ({ actions }) => {
     createTypes(typeDefs);
   }
 };
+async function createBlogNode(options, actions, node, cache) {
+  let { basePath = '', blogPageBasePath = 'blog' } = options;
+  const { createNodeField } = actions;
+  basePath = removeTrailingLeadingSlashes(basePath);
+  if (blogPageBasePath.length > 0) {
+    blogPageBasePath = removeTrailingLeadingSlashes(blogPageBasePath);
+  }
+  let nodeUrlArray = node.url.split('/');
+  let blogHandle = nodeUrlArray[nodeUrlArray.length - 1];
+  // As while creating only new nodes we do not know about already existing
+  // We need to store information about blogs received early in cache.
+  // 1. Push new blogs to array
+  availableBlogs.push({
+    shopifyId: node.shopifyId,
+    handle: blogHandle,
+  });
+  // 2. Receive already known blogs from cache
+  let blogs = await cache.get('availableBlogs');
+  // 3. Concat new blogs with already known
+  if (blogs && blogs.length > 0) {
+    availableBlogs = availableBlogs.concat(blogs);
+  }
+  // 4. Write back to cache
+  await cache.set('availableBlogs', availableBlogs);
+  // Todo: Improve the way this is done. Maybe using the config.json file.
+  createNodeField({
+    node,
+    name: 'shopifyThemePath',
+    value: `${basePath && `/${basePath}`}${blogPageBasePath &&
+      `/${blogPageBasePath}`}/${blogHandle}`,
+  });
+}
+
 async function createArticleNode(options, actions, node, cache) {
   let { basePath = '', articlePageBasePath = 'article', blogPageBasePath = 'blog', } = options;
   const { createNodeField } = actions;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -82,18 +82,7 @@ exports.onCreateNode = async ({ node, actions, cache }, options) => {
   }
 
   if (node.internal.type === `ShopifyPage`) {
-    let { basePath = '', pageBasePath = 'pages' } = options;
-    const { createNodeField } = actions;
-    basePath = removeTrailingLeadingSlashes(basePath);
-    pageBasePath = removeTrailingLeadingSlashes(pageBasePath);
-
-    // Todo: Improve the way this is done. Maybe using the config.json file.
-    createNodeField({
-      node,
-      name: 'shopifyThemePath',
-      value: `${basePath && `/${basePath}`}${pageBasePath &&
-        `/${pageBasePath}`}/${node.handle}`,
-    });
+    createPageNode(options, actions, node);
   }
 
   if (node.internal.type === `ShopifyBlog`) {
@@ -200,6 +189,20 @@ exports.sourceNodes = ({ actions }) => {
     createTypes(typeDefs);
   }
 };
+function createPageNode(options, actions, node) {
+  let { basePath = '', pageBasePath = 'pages' } = options;
+  const { createNodeField } = actions;
+  basePath = removeTrailingLeadingSlashes(basePath);
+  pageBasePath = removeTrailingLeadingSlashes(pageBasePath);
+  // Todo: Improve the way this is done. Maybe using the config.json file.
+  createNodeField({
+    node,
+    name: 'shopifyThemePath',
+    value: `${basePath && `/${basePath}`}${pageBasePath &&
+      `/${pageBasePath}`}/${node.handle}`,
+  });
+}
+
 async function createBlogNode(options, actions, node, cache) {
   let { basePath = '', blogPageBasePath = 'blog' } = options;
   const { createNodeField } = actions;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -50,21 +50,7 @@ exports.onCreateNode = async ({ node, actions, cache }, options) => {
   }
 
   if (node.internal.type === `ShopifyCollection`) {
-    let { basePath = '', collectionPageBasePath = 'collection' } = options;
-    const { createNodeField } = actions;
-    basePath = removeTrailingLeadingSlashes(basePath);
-    collectionPageBasePath = removeTrailingLeadingSlashes(
-      collectionPageBasePath
-    );
-
-    // Todo: Improve the way this is done. Maybe using the config.json file.
-    createNodeField({
-      node,
-      name: 'shopifyThemePath',
-      value: `${basePath && `/${basePath}`}/${collectionPageBasePath}/${
-        node.handle
-      }`,
-    });
+    createCollectionNode(options, actions, node);
   }
 
   if (node.internal.type === `ShopifyShopPolicy`) {
@@ -179,6 +165,19 @@ exports.sourceNodes = ({ actions }) => {
     createTypes(typeDefs);
   }
 };
+function createCollectionNode(options, actions, node) {
+  let { basePath = '', collectionPageBasePath = 'collection' } = options;
+  const { createNodeField } = actions;
+  basePath = removeTrailingLeadingSlashes(basePath);
+  collectionPageBasePath = removeTrailingLeadingSlashes(collectionPageBasePath);
+  // Todo: Improve the way this is done. Maybe using the config.json file.
+  createNodeField({
+    node,
+    name: 'shopifyThemePath',
+    value: `${basePath && `/${basePath}`}/${collectionPageBasePath}/${node.handle}`,
+  });
+}
+
 function createShopPolicyNode(options, actions, node) {
   let { basePath = '', policyPageBasePath = 'policy' } = options;
   const { createNodeField } = actions;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -105,51 +105,51 @@ exports.createPages = async ({ graphql, actions }, options) => {
   }
 };
 
-exports.sourceNodes = ({ actions }) => {
+exports.createSchemaCustomization =({ actions }) => {
   const { createTypes } = actions;
   // In case using Shopify Lite plan GraphQL nodes for Articles and Pages are not created.
   // While build process GatsbyJS extracts queries and checks them against schema (see https://www.gatsbyjs.org/docs/query-extraction/).
   // Here we are creating mock data, so the queries could pass validation.
-  if (isShopifyLite) {
-    const typeDefs = `
-        type ShopifyArticleFields {
-          shopifyThemePath: String
-        }
-        type ShopifyBlog implements Node {
-          Name: String
-          title: String
-          url: String
-          shopifyId: String
-          fields: ShopifyArticleFields
-        }
-        type ShopifyArticle implements Node {
-          Name: String
-          content: String
-          contentHtml: String
-          excerpt: String
-          excerptHtml: String
-          blog: ShopifyBlog
-          publishedAt(formatString: String): Date
-          title: String
-          url: String
-          shopifyId: String
-          fields: ShopifyArticleFields
-        }
-        type ShopifyPage implements Node {
-          Name: String
-          handle: String
-          title: String
-          body: String
-          bodySummary: String
-          updatedAt(formatString: String): Date
-          url: String
-          shopifyId: String
-          fields: ShopifyArticleFields
-        }
+  
+  const typeDefs = `
+      type ShopifyArticleFields {
+        shopifyThemePath: String
+      }
+      type ShopifyBlog implements Node {
+        Name: String
+        title: String
+        url: String
+        shopifyId: String
+        fields: ShopifyArticleFields
+      }
+      type ShopifyArticle implements Node {
+        Name: String
+        content: String
+        contentHtml: String
+        excerpt: String
+        excerptHtml: String
+        blog: ShopifyBlog
+        publishedAt(formatString: String): Date
+        title: String
+        url: String
+        shopifyId: String
+        fields: ShopifyArticleFields
+      }
+      type ShopifyPage implements Node {
+        Name: String
+        handle: String
+        title: String
+        body: String
+        bodySummary: String
+        updatedAt(formatString: String): Date
+        url: String
+        shopifyId: String
+        fields: ShopifyArticleFields
+      }
   `;
-    createTypes(typeDefs);
-  }
+  createTypes(typeDefs);
 };
+
 function createProductNode(options, actions, node) {
   let { basePath = '', productPageBasePath = 'product' } = options;
   const { createNodeField } = actions;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -276,31 +276,7 @@ exports.createPages = async ({ graphql, actions }, options) => {
     }
   );
 
-  const queryProducts = await graphql(`
-    {
-      products: allShopifyProduct {
-        nodes {
-          handle
-          fields {
-            shopifyThemePath
-          }
-        }
-      }
-    }
-  `);
-  queryProducts.data.products.nodes.forEach(({ handle, fields }) => {
-    const { shopifyThemePath } = fields;
-    createPage({
-      path: shopifyThemePath,
-      component: productTemplate,
-      context: {
-        handle,
-
-        // Todo: Find a better way to do this.
-        cartUrl: finalCartPagePath,
-      },
-    });
-  });
+  await createProductsPages(graphql, createPage, finalCartPagePath);
 
   await createPoliciesPages(graphql, createPage, finalCartPagePath);
 
@@ -359,6 +335,33 @@ exports.sourceNodes = ({ actions }) => {
     createTypes(typeDefs);
   }
 };
+async function createProductsPages(graphql, createPage, finalCartPagePath) {
+  const queryProducts = await graphql(`
+    {
+      products: allShopifyProduct {
+        nodes {
+          handle
+          fields {
+            shopifyThemePath
+          }
+        }
+      }
+    }
+  `);
+  queryProducts.data.products.nodes.forEach(({ handle, fields }) => {
+    const { shopifyThemePath } = fields;
+    createPage({
+      path: shopifyThemePath,
+      component: productTemplate,
+      context: {
+        handle,
+        // Todo: Find a better way to do this.
+        cartUrl: finalCartPagePath,
+      },
+    });
+  });
+}
+
 async function createPoliciesPages(graphql, createPage, finalCartPagePath) {
   const queryPolicies = await graphql(`
     {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -33,29 +33,26 @@ const getMainPageHandles = mainPage => {
 };
 
 exports.onCreateNode = async ({ node, actions, cache }, options) => {
-  if (node.internal.type === `ShopifyProduct`) {
-    createProductNode(options, actions, node);
-  }
-
-  if (node.internal.type === `ShopifyCollection`) {
-    createCollectionNode(options, actions, node);
-  }
-
-  if (node.internal.type === `ShopifyShopPolicy`) {
-    createShopPolicyNode(options, actions, node);
-  }
-
-  if (node.internal.type === `ShopifyPage`) {
-    createPageNode(options, actions, node);
-  }
-
-  if (node.internal.type === `ShopifyBlog`) {
-    await createBlogNode(options, actions, node, cache);
-  }
-
-  if (node.internal.type === `ShopifyArticle`) {
-    await createArticleNode(options, actions, node, cache);
-  }
+  switch (node.internal.type) {
+    case `ShopifyProduct`:
+      createProductNode(options, actions, node);
+      break;
+    case `ShopifyCollection`:
+      createCollectionNode(options, actions, node);
+      break;
+    case `ShopifyShopPolicy`:
+      createShopPolicyNode(options, actions, node);
+      break;
+    case `ShopifyPage`:
+      createPageNode(options, actions, node);
+      break;
+    case `ShopifyBlog`:
+      await createBlogNode(options, actions, node, cache);
+      break;
+    case `ShopifyArticle`:
+      await createArticleNode(options, actions, node, cache);
+      break; 
+    }
 };
 
 exports.createPages = async ({ graphql, actions }, options) => {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -68,17 +68,7 @@ exports.onCreateNode = async ({ node, actions, cache }, options) => {
   }
 
   if (node.internal.type === `ShopifyShopPolicy`) {
-    let { basePath = '', policyPageBasePath = 'policy' } = options;
-    const { createNodeField } = actions;
-    basePath = removeTrailingLeadingSlashes(basePath);
-    policyPageBasePath = removeTrailingLeadingSlashes(policyPageBasePath);
-
-    // Todo: Improve the way this is done. Maybe using the config.json file.
-    createNodeField({
-      node,
-      name: 'shopifyThemePath',
-      value: `${basePath && `/${basePath}`}/${policyPageBasePath}/${node.type}`,
-    });
+    createShopPolicyNode(options, actions, node);
   }
 
   if (node.internal.type === `ShopifyPage`) {
@@ -189,6 +179,19 @@ exports.sourceNodes = ({ actions }) => {
     createTypes(typeDefs);
   }
 };
+function createShopPolicyNode(options, actions, node) {
+  let { basePath = '', policyPageBasePath = 'policy' } = options;
+  const { createNodeField } = actions;
+  basePath = removeTrailingLeadingSlashes(basePath);
+  policyPageBasePath = removeTrailingLeadingSlashes(policyPageBasePath);
+  // Todo: Improve the way this is done. Maybe using the config.json file.
+  createNodeField({
+    node,
+    name: 'shopifyThemePath',
+    value: `${basePath && `/${basePath}`}/${policyPageBasePath}/${node.type}`,
+  });
+}
+
 function createPageNode(options, actions, node) {
   let { basePath = '', pageBasePath = 'pages' } = options;
   const { createNodeField } = actions;


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

ShopifyLite fix and CleanCode
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**:

During `exports.sourceNodes`, `isShopifyLite` is `false`, so when it
gets to `exports.createPages` the dummy types Blog, Articles are not there.

However, since `sourceNodes` is before run it creates initial GraphQL schema
in the Gatbsy bootstrap sequence, `shopifyLite` cannot be queried with
graphql.



**How**:

The `createTypes` call seems more properly suited in [`createSchemaCustomization`](https://www.gatsbyjs.org/docs/node-apis/#createSchemaCustomization) however,
still, this is before the schema generation. Therefore it is done for all Shopify plans, not only Shopify lite.

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added/updated
- [ ] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
