### PR TITLE
Stops no altText from breaking the build

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -570,7 +570,10 @@ exports.createSchemaCustomization = ({ actions }) => {
       link: String
     }
     type ShopifyProductFieldsFirstImage {
+      id: String
       altText: String
+      originalSrc: String
+      localFile: File
     }
 `;
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -569,6 +569,9 @@ exports.createSchemaCustomization = ({ actions }) => {
       name: String
       link: String
     }
+    type ShopifyProductFieldsFirstImage {
+      altText: String
+    }
 `;
 
   // In case using Shopify Lite plan GraphQL nodes for Articles and Pages are not created.


### PR DESCRIPTION
If someone fails to add altText in shopify (which isn't really enforced even if it is beneficial) the whole build breaks if this is the first image for a product.

<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

If a user fails to include an altText for the first image of a product the build fails

**Why**:

stops the build failing

**How**:

changes to gatsby-node.js schema definition

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added/updated
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
Thanks for a great Gatsby Starter!