### PR TITLE
feat: use gatsby-plugin-layout

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -100,6 +100,12 @@ const config = ({
       },
     },
     'gatsby-plugin-loadable-components-ssr',
+    {
+      resolve: `gatsby-plugin-layout`,
+      options: {
+        component: require.resolve(`./src/components/Layout.jsx`),
+      },
+    },
   ];
 
   const siteMetadata = {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@theme-ui/presets": "^0.2.42",
     "body-scroll-lock": "^3.0.3",
     "elasticlunr": "^0.9.5",
+    "gatsby-plugin-layout": "^1.8.0",
     "gatsby-plugin-lint-queries": "^0.0.3",
     "gatsby-plugin-loadable-components-ssr": "^2.1.0",
     "gatsby-plugin-manifest": "^2.2.29",

--- a/src/components/Menu/index.jsx
+++ b/src/components/Menu/index.jsx
@@ -150,6 +150,7 @@ const Menu = ({ menu: componentMenu }) => {
                                 to={`/${element.type}/${element.handle}`}
                                 key={element.id}
                                 style={{ textDecoration: 'none' }}
+                                onClick={toggleSidebar}
                               >
                                 <MenuItem
                                   bg="menuItem"

--- a/src/components/Search/index.jsx
+++ b/src/components/Search/index.jsx
@@ -142,6 +142,7 @@ const Search = () => {
                         as={GatsbyLink}
                         variant="searchLink"
                         to={page.shopifyThemePath}
+                        onClick={toggleSidebar}
                       >
                         <Box>{page.title}</Box>
                       </Text>

--- a/src/pages/404.jsx
+++ b/src/pages/404.jsx
@@ -2,11 +2,10 @@ import React from 'react';
 import Helmet from 'react-helmet';
 import { Flex, Box, Text } from 'rebass';
 import GatsbyLink from 'gatsby-link';
-import Layout from '../components/Layout';
 
 function Home() {
   return (
-    <Layout>
+    <>
       <Helmet title="Not found" defer={false} />
       <Flex mt={6} px={[3, null, 4]} justifyContent="center">
         <Box>
@@ -31,7 +30,7 @@ function Home() {
           </Text>
         </Box>
       </Flex>
-    </Layout>
+    </>
   );
 }
 

--- a/src/templates/cart/index.jsx
+++ b/src/templates/cart/index.jsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import CartPage from './CartPage';
 import { Helmet } from 'react-helmet';
-import Layout from '../../components/Layout';
+
 import strings from './strings.json';
 
 const { pageTitle, pageDescription } = strings;
 
-export default props => {
+export default (props) => {
   return (
-    <Layout>
+    <>
       <Helmet title={pageTitle} defer={false}>
         <meta name="description" content={pageDescription} />
       </Helmet>
       <CartPage {...props} />
-    </Layout>
+    </>
   );
 };

--- a/src/templates/catalog/index.jsx
+++ b/src/templates/catalog/index.jsx
@@ -1,19 +1,19 @@
 import React from 'react';
 import { graphql } from 'gatsby';
 import { Helmet } from 'react-helmet';
-import Layout from '../../components/Layout';
+
 import CatalogPage from './CatalogPage';
 
 export default (props) => {
   const { title, description } = props.data.collection.nodes[0];
   const { storeName } = props.data.store.siteMetadata.gatsbyStorefrontConfig;
   return (
-    <Layout>
+    <>
       <Helmet title={title} titleTemplate={`%s — ${storeName}`} defer={false}>
         <meta name="description" content={description} />
       </Helmet>
       <CatalogPage {...props} />
-    </Layout>
+    </>
   );
 };
 

--- a/src/templates/main/index.jsx
+++ b/src/templates/main/index.jsx
@@ -4,7 +4,6 @@ import { Helmet } from 'react-helmet';
 import { graphql } from 'gatsby';
 
 import MainPage from './MainPage';
-import Layout from '../../components/Layout';
 import strings from './strings.json';
 
 const { pageTitleTemplate } = strings;
@@ -16,12 +15,12 @@ export default (props) => {
   } = props.data.store.siteMetadata.gatsbyStorefrontConfig;
 
   return (
-    <Layout>
+    <>
       <Helmet title={storeName} titleTemplate={pageTitleTemplate} defer={false}>
         <meta name="description" content={storeDescription} />
       </Helmet>
       <MainPage {...props} />
-    </Layout>
+    </>
   );
 };
 

--- a/src/templates/policy/index.jsx
+++ b/src/templates/policy/index.jsx
@@ -1,14 +1,10 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import Layout from '../../components/Layout';
+
 import PolicyPage from './PolicyPage';
 
-export default props => {
-  return (
-    <Layout>
-      <PolicyPage {...props} />
-    </Layout>
-  );
+export default (props) => {
+  return <PolicyPage {...props} />;
 };
 
 export const policyQuery = graphql`

--- a/src/templates/product/index.jsx
+++ b/src/templates/product/index.jsx
@@ -3,16 +3,15 @@ import { Helmet } from 'react-helmet';
 import { graphql } from 'gatsby';
 
 import ProductPage from './ProductPage';
-import Layout from '../../components/Layout';
 
 export default (props) => {
   const { title } = props.data.product;
   const { storeName } = props.data.store.siteMetadata.gatsbyStorefrontConfig;
   return (
-    <Layout>
+    <>
       <Helmet title={title} titleTemplate={`%s — ${storeName}`} defer={false} />
       <ProductPage {...props} />
-    </Layout>
+    </>
   );
 };
 


### PR DESCRIPTION
The plugin is setting wrapper component around pages that won’t get
unmounted on page changes.

<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added/updated
- [ ] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
